### PR TITLE
Create exo version of Backstopjs docker image to apply the workaround to use it in Jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM backstopjs/backstopjs:v3.2.15
+LABEL MAINTAINER "eXo Platform <docker@exoplatform.com>"
+
+# Workaround to be able to execute others command than "backstopjs" as entrypoint
+COPY docker-entrypoint.sh /usr/bin/docker-entrypoint
+RUN chmod u+x /usr/bin/docker-entrypoint
+ENTRYPOINT ["/usr/bin/docker-entrypoint"]
+
+CMD ["backstop"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Hack for Jenkins Pipeline: authorize cat without absolute path
+if [[ "$1" == "/"* ]] || [[ "$1" == "cat" ]]; then
+  exec "$@"
+fi
+
+exec backstop "$@"


### PR DESCRIPTION
This PR creates a docker image for backstopjs with the hack to make it works in Jenkins pipeline jobs (like exo-ci images).
The version v3.2.15 is used since it is the version tested during the PoC.